### PR TITLE
docs: add QED box guidance for MathJax proofs

### DIFF
--- a/_posts/2025-05-01-Markdown's-Grammar.md
+++ b/_posts/2025-05-01-Markdown's-Grammar.md
@@ -264,6 +264,14 @@ math: true
 - **内嵌数学公式** (在行内) 必须添加 `$ math $` ，`$` 前后不得有任何空行
 - **内嵌数学公式** (列表中) 必须添加 `\$$ math $$`
 
+> 如果公式中包含 `{`、`}` 或 `\left\{`、`\right\}` 等花括号，在 Jekyll/Chirpy 中可能会被 Liquid 误解析而丢失。
+> 解决方法之一是将包含花括号的公式包裹在 `{% raw %}` 与 `{% endraw %}` 中，避免 Liquid 处理。
+{: .prompt-warning }
+
+> 证明末尾的小正方形建议直接用数学符号完成对齐，避免使用 `<p>` 或 `align` 造成额外空行。
+> 例如行内用 `\(\square\)`，或在块公式末尾用 `\hfill \square` 实现右对齐。
+{: .prompt-tip }
+
 ```markdown
 <!-- Block math, keep all blank lines -->
 
@@ -280,6 +288,22 @@ $$
 1. \$$ LaTeX_math_expression $$
 2. \$$ LaTeX_math_expression $$
 3. \$$ LaTeX_math_expression $$
+
+<!-- Prevent Liquid from eating curly braces -->
+
+{% raw %}
+$$
+\left\{ x \in \mathbb{R} \mid x > 0 \right\}
+$$
+{% endraw %}
+
+<!-- Proof end with a QED box (inline or right-aligned) -->
+
+The proof is complete. \(\square\)
+
+$$
+\text{Proof.}\ \ldots\ \hfill \square
+$$
 ```
 
 ## 表格


### PR DESCRIPTION
### Motivation
- Avoid extra paragraph gaps introduced by HTML/`align` when placing a proof-ending square, and show a simpler MathJax-based approach that works cleanly with Jekyll/Chirpy.

### Description
- Update `_posts/2025-05-01-Markdown's-Grammar.md` to add a tip recommending using MathJax `\(\square\)` inline or `\hfill \square` inside block math for right alignment, include short examples for both, and retain the `{% raw %}`/`{% endraw %}` workaround guidance for curly braces.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698934fba1148330b1dd56d51b1ea9fd)